### PR TITLE
Allow to use backhandler in wasm target

### DIFF
--- a/example/composeApp/src/wasmJsMain/kotlin/main.kt
+++ b/example/composeApp/src/wasmJsMain/kotlin/main.kt
@@ -1,22 +1,50 @@
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.*
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.CanvasBasedWindow
+import com.composegears.tiamat.LocalNavBackHandler
 import content.examples.koin.KoinLib
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     KoinLib.start()
+    val focusRequester = FocusRequester()
+
     CanvasBasedWindow(canvasElementId = "TiamatTarget") {
         PageLoadNotify()
-        Box {
+
+        // workaround to make window always focused
+        LaunchedEffect(Unit) {
+            while (true) {
+                delay(100)
+                focusRequester.requestFocus()
+            }
+        }
+        val backHandler = LocalNavBackHandler.current
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .focusRequester(focusRequester)
+                .focusTarget()
+                .onKeyEvent {
+                    it.key == Key.Escape && it.type == KeyEventType.KeyUp && backHandler.back()
+                }
+        ) {
             App()
             Text(
                 modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ android-minSdk = "21"
 android-targetSdk = "34"
 
 detekt = "1.23.6"
-jetbrains-compose = "1.6.2"
+jetbrains-compose = "1.6.10-dev1580"
 kotlin = "2.0.0-RC1"
 
 [libraries]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,10 +11,10 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    @Suppress("UnstableApiUsage")
     repositories {
         google()
         mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }
 

--- a/tiamat/src/wasmJsMain/kotlin/com/composegears/tiamat/NavBackHandler.kt
+++ b/tiamat/src/wasmJsMain/kotlin/com/composegears/tiamat/NavBackHandler.kt
@@ -1,0 +1,18 @@
+package com.composegears.tiamat
+
+class NavBackHandler {
+
+    private val backHandlers = ArrayList<() -> Unit>()
+
+    fun back(): Boolean = backHandlers
+        .lastOrNull()
+        ?.invoke() != null
+
+    fun add(callback: () -> Unit) {
+        backHandlers.add(callback)
+    }
+
+    fun remove(callback: () -> Unit) {
+        backHandlers.remove(callback)
+    }
+}

--- a/tiamat/src/wasmJsMain/kotlin/com/composegears/tiamat/Platform.wasm.kt
+++ b/tiamat/src/wasmJsMain/kotlin/com/composegears/tiamat/Platform.wasm.kt
@@ -1,6 +1,10 @@
 package com.composegears.tiamat
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalNavBackHandler = staticCompositionLocalOf { NavBackHandler() }
 
 /**
  * Global in-memory data storage
@@ -24,10 +28,21 @@ internal actual fun <Args> NavDestinationScope<Args>.PlatformContentWrapper(
 }
 
 /**
- * No back button
+ * Platform provided system back handler
  */
 @Composable
-actual fun NavBackHandler(enabled: Boolean, onBackEvent: () -> Unit) = Unit
+actual fun NavBackHandler(enabled: Boolean, onBackEvent: () -> Unit) {
+    if (enabled) {
+        val backHandler = LocalNavBackHandler.current
+        DisposableEffect(Unit) {
+            val callback = { onBackEvent() }
+            backHandler.add(callback)
+            onDispose {
+                backHandler.remove(callback)
+            }
+        }
+    }
+}
 
 /**
  * We can not call T::class in @Composable functions,


### PR DESCRIPTION
blocked by https://github.com/JetBrains/compose-multiplatform/issues/4673