### PR TITLE
Use latest stable supported AGP in IntelliJ IDEA

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.0-alpha05"
+agp = "8.7.3"
 android-compileSdk = "35"
 android-minSdk = "21"
 android-targetSdk = "35"


### PR DESCRIPTION
IDEA 2024.3.3 AGP supported version is 8.8.0-alpha05.
Let's use only stable one