### PR TITLE
Fix LifecycleModel creation

### DIFF
--- a/tiamat/src/androidMain/kotlin/com/composegears/tiamat/compose/DestinationLifecycle.kt
+++ b/tiamat/src/androidMain/kotlin/com/composegears/tiamat/compose/DestinationLifecycle.kt
@@ -66,7 +66,7 @@ private class LifecycleModel : ViewModel(), LifecycleOwner, LifecycleEventObserv
 @Composable
 @Suppress("ViewModelInjection")
 internal fun rememberDestinationLifecycleOwner(): LifecycleOwner {
-    val lifecycleModel = viewModel<LifecycleModel>()
+    val lifecycleModel = viewModel { LifecycleModel() }
     val parentLifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleModel) {
         lifecycleModel.onAttach()


### PR DESCRIPTION
Fix runtime crash

Thanks @maxlordks 

crash log:

```kotlin
17:12:10.618  E  FATAL EXCEPTION: main
                 Process: composegears.tiamat.example, PID: 891
                 java.lang.RuntimeException: Cannot create an instance of class com.composegears.tiamat.compose.LifecycleModel
                 	at androidx.lifecycle.viewmodel.internal.JvmViewModelProviders.createViewModel(JvmViewModelProviders.kt:44)
                 	at androidx.lifecycle.ViewModelProvider$NewInstanceFactory.create(ViewModelProvider.android.kt:185)
                 	at androidx.lifecycle.ViewModelProvider$AndroidViewModelFactory.create(ViewModelProvider.android.kt:309)
                 	at androidx.lifecycle.ViewModelProvider$AndroidViewModelFactory.create(ViewModelProvider.android.kt:291)
                 	at androidx.lifecycle.ViewModelProvider$AndroidViewModelFactory.create(ViewModelProvider.android.kt:265)
                 	at androidx.lifecycle.SavedStateViewModelFactory.create(SavedStateViewModelFactory.android.kt:142)
                 	at androidx.lifecycle.SavedStateViewModelFactory.create(SavedStateViewModelFactory.android.kt:112)
                 	at androidx.lifecycle.viewmodel.ViewModelProviderImpl_androidKt.createViewModel(ViewModelProviderImpl.android.kt:34)
                 	at androidx.lifecycle.viewmodel.ViewModelProviderImpl.getViewModel$lifecycle_viewmodel_release(ViewModelProviderImpl.kt:60)
                 	at androidx.lifecycle.viewmodel.ViewModelProviderImpl.getViewModel$lifecycle_viewmodel_release$default(ViewModelProviderImpl.kt:43)
                 	at androidx.lifecycle.ViewModelProvider.get(ViewModelProvider.android.kt:92)
                 	at androidx.lifecycle.viewmodel.compose.ViewModelKt__ViewModelKt.get(ViewModel.kt:172)
                 	at androidx.lifecycle.viewmodel.compose.ViewModelKt.get(Unknown Source:1)
                 	at androidx.lifecycle.viewmodel.compose.ViewModelKt__ViewModel_androidKt.viewModel(ViewModel.android.kt:119)
                 	at androidx.lifecycle.viewmodel.compose.ViewModelKt.viewModel(Unknown Source:1)
                 	at com.composegears.tiamat.compose.DestinationLifecycleKt.rememberDestinationLifecycleOwner(DestinationLifecycle.kt:69)
                 	at com.composegears.tiamat.compose.ComposePlatform_androidKt.PlatformContentWrapper(ComposePlatform.android.kt:14)
                 	at com.composegears.tiamat.compose.ComposeKt.NavEntryContent$lambda$32$lambda$28(Compose.kt:184)
                 	at com.composegears.tiamat.compose.ComposeKt.$r8$lambda$bCJUSTolRkTkIDYGt-2wJGXCTuM(Unknown Source:0)
                 	at com.composegears.tiamat.compose.ComposeKt$$ExternalSyntheticLambda10.invoke(D8$$SyntheticClass:0)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:121)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:51)
                 	at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:364)
                 	at com.composegears.tiamat.compose.ComposeKt.NavEntryContent(Compose.kt:178)
                 	at com.composegears.tiamat.compose.ComposeKt.NavigationScene$lambda$73$lambda$72$lambda$71(Compose.kt:442)
                 	at com.composegears.tiamat.compose.ComposeKt.$r8$lambda$T_DCp6-KA044jqOTtp6oJKRMWj4(Unknown Source:0)
                 	at com.composegears.tiamat.compose.ComposeKt$$ExternalSyntheticLambda23.invoke(D8$$SyntheticClass:0)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:130)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:51)
                 	at com.composegears.tiamat.compose.NavigationSceneScope.EntryContent(NavigationSceneScope.kt:39)
                 	at com.composegears.tiamat.compose.ComposeKt.Navigation$lambda$59$lambda$58$lambda$57(Compose.kt:332)
                 	at com.composegears.tiamat.compose.ComposeKt.$r8$lambda$N8N1W8Yyt61eD69KG3IGczWTYyI(Unknown Source:0)
                 	at com.composegears.tiamat.compose.ComposeKt$$ExternalSyntheticLambda3.invoke(D8$$SyntheticClass:0)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:121)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:51)
                 	at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:384)
                 	at com.composegears.tiamat.compose.ComposeKt.Navigation$lambda$59$lambda$58(Compose.kt:328)
                 	at com.composegears.tiamat.compose.ComposeKt.$r8$lambda$AESw3vTrtp_kgDEyazJppcL0NyQ(Unknown Source:0)
17:12:10.619  E  	at com.composegears.tiamat.compose.ComposeKt$$ExternalSyntheticLambda6.invoke(D8$$SyntheticClass:0)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:142)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:51)
                 	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1$5.invoke(AnimatedContent.kt:862)
                 	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1$5.invoke(AnimatedContent.kt:852)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:130)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:51)
                 	at androidx.compose.animation.AnimatedVisibilityKt.AnimatedEnterExitImpl(AnimatedVisibility.kt:755)
                 	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1.invoke(AnimatedContent.kt:834)
                 	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1.invoke(AnimatedContent.kt:817)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:121)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:51)
                 	at androidx.compose.animation.AnimatedContentKt.AnimatedContent(AnimatedContent.kt:872)
                 	at com.composegears.tiamat.compose.ComposeKt.Navigation$lambda$59(Compose.kt:305)
                 	at com.composegears.tiamat.compose.ComposeKt.$r8$lambda$V56z_vRtVrPgJcun8wfIj1ctaYo(Unknown Source:0)
                 	at com.composegears.tiamat.compose.ComposeKt$$ExternalSyntheticLambda18.invoke(D8$$SyntheticClass:0)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.kt:130)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl$invoke$2.invoke(ComposableLambda.kt:132)
                 	at androidx.compose.runtime.internal.ComposableLambdaImpl$invoke$2.invoke(ComposableLambda.kt:131)
                 	at androidx.compose.runtime.RecomposeScopeImpl.compose(RecomposeScopeImpl.kt:235)
                 	at androidx.compose.runtime.ComposerImpl.recomposeToGroupEnd(Composer.kt:2838)
                 	at androidx.compose.runtime.ComposerImpl.skipCurrentGroup(Composer.kt:3158)
                 	at androidx.compose.runtime.ComposerImpl.doCompose-aFTiNEg(Composer.kt:3706)
                 	at androidx.compose.runtime.ComposerImpl.recompose-aFTiNEg$runtime_release(Composer.kt:3648)
                 	at androidx.compose.runtime.CompositionImpl.recompose(Composition.kt:1002)
                 	at androidx.compose.runtime.Recomposer.performRecompose(Recomposer.kt:1266)
                 	at androidx.compose.runtime.Recomposer.access$performRecompose(Recomposer.kt:142)
                 	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$1.invoke(Recomposer.kt:620)
                 	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$1.invoke(Recomposer.kt:591)
                 	at androidx.compose.ui.platform.AndroidUiFrameClock$withFrameNanos$2$callback$1.doFrame(AndroidUiFrameClock.android.kt:39)
                 	at androidx.compose.ui.platform.AndroidUiDispatcher.performFrameDispatch(AndroidUiDispatcher.android.kt:108)
                 	at androidx.compose.ui.platform.AndroidUiDispatcher.access$performFrameDispatch(AndroidUiDispatcher.android.kt:41)
                 	at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.doFrame(AndroidUiDispatcher.android.kt:69)
                 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1568)
                 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1579)
                 	at android.view.Choreographer.doCallbacks(Choreographer.java:1179)
                 	at android.view.Choreographer.doFrame(Choreographer.java:1104)
                 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1553)
                 	at android.os.Handler.handleCallback(Handler.java:995)
                 	at android.os.Handler.dispatchMessage(Handler.java:103)
                 	at android.os.Looper.loopOnce(Looper.java:248)
                 	at android.os.Looper.loop(Looper.java:338)
                 	at android.app.ActivityThread.main(ActivityThread.java:9067)
                 	at java.lang.reflect.Method.invoke(Native Method)
                 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
                 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)
17:12:10.621  E  	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [androidx.compose.runtime.PausableMonotonicFrameClock@fef4746, androidx.compose.ui.platform.MotionDurationScaleImpl@6bcdd07, StandaloneCoroutine{Cancelling}@42c6e34, AndroidUiDispatcher@b6f45d]
                 Caused by: java.lang.IllegalAccessException: java.lang.Class<com.composegears.tiamat.compose.LifecycleModel> is not accessible from java.lang.Class<androidx.lifecycle.viewmodel.internal.JvmViewModelProviders>
                 	at java.lang.reflect.Constructor.newInstance0(Native Method)
                 	at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
                 	at androidx.lifecycle.viewmodel.internal.JvmViewModelProviders.createViewModel(JvmViewModelProviders.kt:38)
                 	... 83 more
```