### PR TITLE
Intercept touch events only on non-current entry. (#196)

### DIFF
--- a/tiamat/src/commonMain/kotlin/com/composegears/tiamat/compose/Compose.kt
+++ b/tiamat/src/commonMain/kotlin/com/composegears/tiamat/compose/Compose.kt
@@ -341,9 +341,7 @@ public fun Navigation(
             ) {
                 Box {
                     EntryContent(it)
-                    // prevent clicks during transition animation
-                    val isCurrent = remember(it, state) { it.contentKey() == state?.targetEntry?.contentKey() }
-                    if (!isCurrent && transition.isRunning) Box(
+                    if (it != targetValue && transition.isRunning) Box(
                         modifier = Modifier
                             .matchParentSize()
                             .pointerInput(Unit) {


### PR DESCRIPTION
link to issue: (#196)

I firstly just feel about the preventing logic is not cool that i have to wait for the transition fully finished then i can navigate to another screen, then i found the double-tap problem you metioned, so i try to handle it by myself. @vkatz  

I make a plan that intercept touches while forwarding and ignore touches while backwarding, but there is no pointerInteropFilter() on Compose Multiplatform, and the structure in AnimatedContent can't fit for sharePointerInputWithSiblings(), i found no way to ignore touches on the top entry while backwarding.

Only optimization i can do on is the intercept touches logic, now the navigation will be more smooth while forwarding, since no changes while backwarding.