### PR TITLE
Remove unnecessary dependency on androidx.concurrent.futures and simplify camera provider usage

### DIFF
--- a/example/platform/build.gradle.kts
+++ b/example/platform/build.gradle.kts
@@ -41,7 +41,6 @@ kotlin {
             implementation(libs.androidx.camera.camera2)
             implementation(libs.androidx.camera.lifecycle)
             implementation(libs.androidx.camera.view)
-            implementation(libs.androidx.concurrent.futures)
         }
     }
 }

--- a/example/platform/src/androidMain/kotlin/composegears/tiamat/example/platform/AndroidViewLifecycleScreen.kt
+++ b/example/platform/src/androidMain/kotlin/composegears/tiamat/example/platform/AndroidViewLifecycleScreen.kt
@@ -12,6 +12,7 @@ import androidx.camera.core.CameraSelector.LENS_FACING_BACK
 import androidx.camera.core.CameraSelector.LENS_FACING_FRONT
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.lifecycle.awaitInstance
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -31,7 +32,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.concurrent.futures.await
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -108,7 +108,7 @@ private fun CameraView() {
             .build()
     }
     LaunchedEffect(lensFacing) {
-        val cameraProvider = ProcessCameraProvider.getInstance(context).await()
+        val cameraProvider = ProcessCameraProvider.awaitInstance(context)
         cameraProvider.unbindAll()
         cameraProvider.bindToLifecycle(
             lifecycleOwner,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ androidx-activity-compose = "androidx.activity:activity-compose:1.10.1"
 androidx-camera-camera2 = "androidx.camera:camera-camera2:1.4.2"
 androidx-camera-lifecycle = "androidx.camera:camera-lifecycle:1.4.2"
 androidx-camera-view = "androidx.camera:camera-view:1.4.2"
-androidx-concurrent-futures = "androidx.concurrent:concurrent-futures-ktx:1.3.0"
 androidx-lifecycle-runtime = "androidx.lifecycle:lifecycle-runtime-ktx:2.9.2"
 
 detekt-compose = "io.nlopez.compose.rules:detekt:0.4.27"


### PR DESCRIPTION
- ref: #137 