### PR TITLE
Remove WASM gradle property, fix iOS path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.ignoreDisabledTargets=true
 
 #IOS
-xcodeproj=./example/app/iosApp
+xcodeproj=./sample/iosApp


### PR DESCRIPTION
looks unnecessary now