### PR TITLE
Fix nav function properties name

### DIFF
--- a/gradle/tiamat.toml
+++ b/gradle/tiamat.toml
@@ -1,5 +1,5 @@
 [versions]
-tiamat = "2.0.0"
+tiamat = "2.1.0"
 
 minSdk = "21"
 compileSdk = "36"

--- a/sample/composeApp/src/commonMain/kotlin/composegears/tiamat/sample/content/architecture/ArchSerializableData.kt
+++ b/sample/composeApp/src/commonMain/kotlin/composegears/tiamat/sample/content/architecture/ArchSerializableData.kt
@@ -41,7 +41,7 @@ val ArchSerializableData by navDestination(ScreenInfo()) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     fun replace(arg: Any) {
                         nc.replace(
-                            entry = ArchSerializableDataScreen,
+                            dest = ArchSerializableDataScreen,
                             navArgs = ArchSerializableDataClass(1),
                             freeArgs = arg,
                         )

--- a/tiamat/src/commonMain/kotlin/com/composegears/tiamat/compose/NavActions.kt
+++ b/tiamat/src/commonMain/kotlin/com/composegears/tiamat/compose/NavActions.kt
@@ -13,20 +13,20 @@ import com.composegears.tiamat.navigation.NavEntry
  * Navigates to a new destination.
  * The current destination is added to the nav stack.
  *
- * @param entry The navigation entry to navigate to
+ * @param dest The destination to navigate to
  * @param navArgs Optional typed arguments to pass to the destination
  * @param freeArgs Optional untyped arguments to pass to the destination
  * @param transition Optional content transform animation for the transition
  * @param transitionController Optional controller for managing the transition programmatically
  */
 public fun <Args : Any> NavController.navigate(
-    entry: NavDestination<Args>,
+    dest: NavDestination<Args>,
     navArgs: Args? = null,
     freeArgs: Any? = null,
     transition: ContentTransform? = null,
     transitionController: TransitionController? = null
 ): Unit = navigate(
-    entry = entry.toNavEntry(
+    entry = dest.toNavEntry(
         navArgs = navArgs,
         freeArgs = freeArgs,
         navResult = null
@@ -61,20 +61,20 @@ public fun <Args : Any> NavController.navigate(
  * Replaces the current destination with a new one.
  * The current destination is not added to the nav stack.
  *
- * @param entry The navigation entry to replace with
+ * @param dest The destination to replace with
  * @param navArgs Optional typed arguments to pass to the destination
  * @param freeArgs Optional untyped arguments to pass to the destination
  * @param transition Optional content transform animation for the transition
  * @param transitionController Optional controller for managing the transition programmatically
  */
 public fun <Args : Any> NavController.replace(
-    entry: NavDestination<Args>,
+    dest: NavDestination<Args>,
     navArgs: Args? = null,
     freeArgs: Any? = null,
     transition: ContentTransform? = null,
     transitionController: TransitionController? = null
 ): Unit = replace(
-    entry = entry.toNavEntry(
+    entry = dest.toNavEntry(
         navArgs = navArgs,
         freeArgs = freeArgs,
         navResult = null


### PR DESCRIPTION
Resolved #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the named parameter in navigation APIs from “entry” to “dest” (e.g., navigate, replace). No behavioral changes; update any named-argument calls accordingly.
  * Updated sample code to align with the new parameter name.

* **Chores**
  * Upgraded Tiamat dependency to version 2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->