### PR TITLE
add android-lint to common-main

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -46,8 +46,8 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
 
-      - name: Execute Gradle build
-        run: ./gradlew detekt
+      - name: Run static analysis (detekt, lint, etc.)
+        run: ./gradlew runStaticAnalysis
 
       - name: Test compiler plugin
         run: ./gradlew tiamat-destinations-compiler:test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     base // expose `clear` task, so we can modify it
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.kotlin.multiplatform.library) apply false
+    alias(libs.plugins.android.lint) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.compose.hot.reload) apply false
     alias(libs.plugins.jetbrains.compose) apply false
@@ -58,6 +59,12 @@ tasks.register("updateAbi") {
     dependsOn(":tiamat:updateLegacyAbi")
     dependsOn(gradle.includedBuild("tiamat-destinations-compiler").task(":updateLegacyAbi"))
     dependsOn(gradle.includedBuild("tiamat-destinations-gradle-plugin").task(":updateLegacyAbi"))
+}
+
+// run static analysis on all projects
+tasks.register("runStaticAnalysis") {
+    dependsOn("detekt")
+    dependsOn(":tiamat:lint")
 }
 
 // root `clean` task not include subprojects by default, so add them directly

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ zacsweers-kctfork = "dev.zacsweers.kctfork:core:0.10.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-lint = { id = "com.android.lint", version.ref = "agp" }
 android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "5.7.0" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/tiamat/build.gradle.kts
+++ b/tiamat/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlinx.kover)
     alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.lint)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.m2p)


### PR DESCRIPTION
Add "android-lint" to "common-main", it allows to catch some rare errors like `removeLast`